### PR TITLE
Updating after testing WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [1.3.3](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.3) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [1.3.2](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.2) - 20-04-2023
 
 ### Added
@@ -12,7 +17,6 @@
 
 ### Added
 - Re added the LSX Container block to allow for page degrading.
-
 
 ## [1.3.0](https://github.com/lightspeeddevelopment/lsx-blocks/releases/tag/1.3.0) - 25-05-2022
 

--- a/lsx-blocks.php
+++ b/lsx-blocks.php
@@ -5,14 +5,14 @@
  * Description: The LSX Blocks plugin gives you a collection of Gutenberg blocks that you can use and customize. All the blocks are built to work with our powerful LSX theme.
  * Author: LightSpeed
  * Author URI: https://www.lsdev.biz/
- * Version: 1.3.2
+ * Version: 1.3.3
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * @package LSX BLOCKS
  */
 
-define( 'LSX_BLOCKS_VER', '1.3.2' );
+define( 'LSX_BLOCKS_VER', '1.3.3' );
 define( 'LSX_BLOCKS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_BLOCKS_CORE', __FILE__ );
 define( 'LSX_BLOCKS_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lsx-blocks",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"private": true,
 	"scripts": {
 		"start": "cgb-scripts start",

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, blocks, gutenberg, block editor, page builder, wordpress blocks
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 8.0
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag